### PR TITLE
Signals

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,3 +20,6 @@ RUN apk add --no-cache --virtual .build-deps \
 COPY attributemaps /home/app/crypt/fvserver/attributemaps
 RUN mv /home/app/crypt/fvserver/urls.py /home/app/crypt/fvserver/origurls.py
 COPY urls.py /home/app/crypt/fvserver/urls.py
+COPY __init__.py /home/app/crypt/server/__init__.py
+COPY apps.py /home/app/crypt/server/apps.py
+COPY signals.py /home/app/crypt/server/signals.py

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'server.apps.ServerAppConfig'

--- a/apps.py
+++ b/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class ServerAppConfig(AppConfig):
+    name = "server"
+
+    def ready(self):
+        import server.signals

--- a/process_build.py
+++ b/process_build.py
@@ -28,6 +28,9 @@ RUN apk add --no-cache --virtual .build-deps \
 COPY attributemaps /home/app/crypt/fvserver/attributemaps
 RUN mv /home/app/crypt/fvserver/urls.py /home/app/crypt/fvserver/origurls.py
 COPY urls.py /home/app/crypt/fvserver/urls.py
+COPY __init__.py /home/app/crypt/server/__init__.py
+COPY apps.py /home/app/crypt/server/apps.py
+COPY signals.py /home/app/crypt/server/signals.py
 
 """.format(
     tag

--- a/settings.py
+++ b/settings.py
@@ -21,6 +21,15 @@ SAML_ATTRIBUTE_MAPPING = {
     "cn": ("first_name",),
     "sn": ("last_name",),
 }
+# Edit these lists to include the names of groups that should get
+# the access levels below. See server/signals.py for more details.
+# Leave blank to disable the group-based permissions feature.
+SAML_ACTIVE_GROUPS = []
+SAML_STAFF_GROUPS = []
+SAML_SUPERUSER_GROUPS = []
+# Edit to match the attribute name used in your SAML assertions for
+# group membership information.
+SAML_GROUPS_ATTRIBUTE = 'memberOf'
 
 if DEBUG == True:
 

--- a/settings.py
+++ b/settings.py
@@ -85,6 +85,9 @@ SAML_CONFIG = {
     "entityid": "https://crypt.example.com/saml2/metadata/",
     # directory with attribute mapping
     "attribute_map_dir": path.join(BASEDIR, "attributemaps"),
+    # Allow SAML assertions to contain attributes not specified in the
+    # attributemaps.
+    'allow_unknown_attributes': True,
     # this block states what services we provide
     "service": {
         # we are just a lonely SP

--- a/signals.py
+++ b/signals.py
@@ -1,0 +1,43 @@
+from django.dispatch import receiver
+
+from djangosaml2.signals import pre_user_save
+
+from django.conf import settings
+
+
+ACTIVE_GROUPS = set(getattr(settings, 'SAML_ACTIVE_GROUPS', []))
+STAFF_GROUPS = set(getattr(settings, 'SAML_READ_ONLY_GROUPS', []))
+SUPERUSER_GROUPS = set(getattr(settings, 'SAML_READ_ONLY_GROUPS', []))
+GROUPS_ATTRIBUTE = getattr(settings, 'SAML_GROUPS_ATTRIBUTE', 'memberOf')
+
+
+@receiver(pre_user_save)
+def update_group_membership(
+        sender, instance, attributes: dict, user_modified: bool, **kwargs) -> bool:
+    """Update user's group membership based on passed SAML groups
+
+    Args:
+        sender: The class of the user that just logged in.
+        instance: User instance
+        attributes: SAML attributes dict.
+        user_modified: Bool whether the user has been modified
+        kwargs:
+            signal: The signal instance
+
+    Returns:
+        Whether or not the user has been modified. This allows the user
+        instance to be saved once at the conclusion of the auth process
+        to keep the writes to a minimum.
+    """
+    assertion_groups = set(attributes.get(GROUPS_ATTRIBUTE, []))
+    if SUPERUSER_GROUPS.intersection(assertion_groups):
+        instance.is_superuser = True
+        user_modified = True
+    if STAFF_GROUPS.intersection(assertion_groups):
+        instance.is_staff = True
+        user_modified = True
+    if ACTIVE_GROUPS.union(STAFF_GROUPS).union(SUPERUSER_GROUPS).intersection(assertion_groups):
+        # All of the groups referenced above should be active.
+        instance.is_active = True
+        user_modified = True
+    return user_modified


### PR DESCRIPTION
This PR adds the (optional) ability to include lists of group memberships in SAML assertions, and then act on membership in those groups to manage Django User's staff, active, and superuser attributes.

As mentioned above, if you don't add any groups to the settings.py, nothing will happen differently than before.

Users without membership in any of the configured groups are not touched.

It is recommended to use the SAML IdP to determine who is and is not allowed to log in; then those that are allowed to login should belong to one of the configured groups.