### PR TITLE
Explicitly call-out trailing slash in URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ Okta has a slightly different implementation and a few of the tools that this co
 
    #### General
 
-   - Single sign on URL: **https://crypt.example.com/saml2/acs/**
+   - Single sign on URL (Note: trailing `/` is important!): **https://crypt.example.com/saml2/acs/**
    - Use this for Recipient URL and Destination URL: **Checked**
    - Allow this app to request other SSO URLs: **Unchecked** (If this option is available)
-   - Audience URI (SP Entity ID): **https://crypt.example.com/saml2/metadata/**
+   - Audience URI (SP Entity ID; Note: trailing `/` is important!): **https://crypt.example.com/saml2/metadata/**
    - Default RelayState: **Unspecified**
    - Application username: **Okta username**
 


### PR DESCRIPTION
Ran into an issue with a missing `/` at end of SAML URLs a bit ago. Search MacAdmins on this issue found some convos from the past few years so figured it might be beneficial to explicitly call-out that the trailing `/` at the end of these SAML URL's is important otherwise Django throws a hissy-fit and you end up debugging this `RuntimeError`:

<img width="828" alt="image" src="https://github.com/grahamgilbert/crypt-server-saml/assets/24925402/823cfa78-9299-4b58-82bd-e7ec7ded4c72">
